### PR TITLE
OutOfMemory exception in SQL editor

### DIFF
--- a/src/GUI/SqlCe35Toolbox/ToolWindows/SqlEditorControl.xaml.cs
+++ b/src/GUI/SqlCe35Toolbox/ToolWindows/SqlEditorControl.xaml.cs
@@ -515,9 +515,10 @@ namespace ErikEJ.SqlCeToolbox.ToolWindows
                     var sql = GetSqlFromSqlEditorTextBox();
                     bool schemaChanged;
                     if (sql.Length == 0) return;
-                    sql = sql.Replace("\r", " \r");
-                    sql = sql.Replace("GO  \r", "GO\r");
-                    sql = sql.Replace("GO \r", "GO\r");
+                    var sbSql = new StringBuilder(sql);
+                    sbSql = sbSql.Replace("\r", " \r");
+                    sbSql = sbSql.Replace("GO  \r", "GO\r");
+                    sql = sbSql.Replace("GO \r", "GO\r").ToString();
                     var sw = new Stopwatch();
                     sw.Start();
                     var dataset = repository.ExecuteSql(sql, out schemaChanged, _ignoreDdlErrors);


### PR DESCRIPTION
This tiny fix deals with an issue which occurs when really big (like > 30 MB) script is run in the editor. It causes OutOfMemory exception. The issue is described here http://stackoverflow.com/questions/16539584/string-replace-vs-stringbuilder-replace-for-memory in details. Hope this helps. And thank you for this outstanding tool.