### PR TITLE
Fix manifest name in VSToolbox

### DIFF
--- a/src/GUI/SqlCe35Toolbox/Properties/Settings1.Designer.cs
+++ b/src/GUI/SqlCe35Toolbox/Properties/Settings1.Designer.cs
@@ -12,7 +12,7 @@ namespace ErikEJ.SqlCeToolbox {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.3.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -296,6 +296,18 @@ namespace ErikEJ.SqlCeToolbox {
             }
             set {
                 this["GetObjectExplorerDatabases"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public string ValidateConnectionsOnStart {
+            get {
+                return ((string)(this["ValidateConnectionsOnStart"]));
+            }
+            set {
+                this["ValidateConnectionsOnStart"] = value;
             }
         }
     }

--- a/src/GUI/SqlCe35Toolbox/app.config
+++ b/src/GUI/SqlCe35Toolbox/app.config
@@ -34,9 +34,6 @@
             <setting name="KeepSchemaNames" serializeAs="String">
                 <value>False</value>
             </setting>
-            <setting name="ValidateConnectionsOnStart" serializeAs="String">
-                <value>False</value>
-            </setting>
             <setting name="MaxColumnWidth" serializeAs="String">
                 <value>0</value>
             </setting>
@@ -74,6 +71,12 @@
                 <value>True</value>
             </setting>
             <setting name="MakeSQLiteDatetimeReadOnly" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="GetObjectExplorerDatabases" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="ValidateConnectionsOnStart" serializeAs="String">
                 <value>False</value>
             </setting>
         </ErikEJ.SqlCeToolbox.Properties.Settings>

--- a/src/GUI/SqlCe35Toolbox/source.extension.vsixmanifest
+++ b/src/GUI/SqlCe35Toolbox/source.extension.vsixmanifest
@@ -2,7 +2,7 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
         <Identity Id="41521019-e4c7-480c-8ea8-fc4a2c6f50aa" Version="4.7.0.0" Language="en-US" Publisher="ErikEJ" />
-        <DisplayName>SQLite / SQL Server Compact Toolbox</DisplayName>
+        <DisplayName>SQLite_SQL_Server_Compact_Toolbox</DisplayName>
         <Description xml:space="preserve">SQLite / SQL Server Compact Toolbox extension for Visual Studio. This extension adds several features to help your embedded database development efforts: Scripting of tables and data, import from SQL Server and CSV files and much, much more.</Description>
         <MoreInfo>https://github.com/ErikEJ/SqlCeToolbox</MoreInfo>
         <License>Resources\license.txt</License>

--- a/src/GUI/SqlCe35Toolbox/source.extension.vsixmanifest
+++ b/src/GUI/SqlCe35Toolbox/source.extension.vsixmanifest
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="41521019-e4c7-480c-8ea8-fc4a2c6f50aa" Version="4.7.0.0" Language="en-US" Publisher="ErikEJ" />
-        <DisplayName>SQLite_SQL_Server_Compact_Toolbox</DisplayName>
-        <Description xml:space="preserve">SQLite / SQL Server Compact Toolbox extension for Visual Studio. This extension adds several features to help your embedded database development efforts: Scripting of tables and data, import from SQL Server and CSV files and much, much more.</Description>
-        <MoreInfo>https://github.com/ErikEJ/SqlCeToolbox</MoreInfo>
-        <License>Resources\license.txt</License>
-        <GettingStartedGuide>https://github.com/ErikEJ/SqlCeToolbox/wiki</GettingStartedGuide>
-        <ReleaseNotes>https://github.com/ErikEJ/SqlCeToolbox/wiki/Release-notes</ReleaseNotes>
-        <Icon>Resources\data_out.ico</Icon>
-        <PreviewImage>Resources\toolbox2.png</PreviewImage>
-        <Tags>sql sqlite sqlce entityframework ef linq codegeneration database ssdt ssms </Tags>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,16.0)" />
-        <InstallationTarget Version="[12.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-        <InstallationTarget Version="[12.0,16.0)" Id="Microsoft.VisualStudio.IntegratedShell" />
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-        <Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="[11.0]" />
-    </Dependencies>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    </Assets>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[11.0,16.0)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
+	<Metadata>
+		<Identity Id="41521019-e4c7-480c-8ea8-fc4a2c6f50aa" Version="4.7.0.0" Language="en-US" Publisher="ErikEJ" />
+		<DisplayName>SQLite SQL Server/Compact Toolbox</DisplayName>
+		<Description xml:space="preserve">SQLite / SQL Server Compact Toolbox extension for Visual Studio. This extension adds several features to help your embedded database development efforts: Scripting of tables and data, import from SQL Server and CSV files and much, much more.</Description>
+		<MoreInfo>https://github.com/ErikEJ/SqlCeToolbox</MoreInfo>
+		<License>Resources\license.txt</License>
+		<GettingStartedGuide>https://github.com/ErikEJ/SqlCeToolbox/wiki</GettingStartedGuide>
+		<ReleaseNotes>https://github.com/ErikEJ/SqlCeToolbox/wiki/Release-notes</ReleaseNotes>
+		<Icon>Resources\data_out.ico</Icon>
+		<PreviewImage>Resources\toolbox2.png</PreviewImage>
+		<Tags>sql sqlite sqlce entityframework ef linq codegeneration database ssdt ssms </Tags>
+	</Metadata>
+	<Installation>
+		<InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,16.0)" />
+		<InstallationTarget Version="[12.0,16.0)" Id="Microsoft.VisualStudio.Community" />
+		<InstallationTarget Version="[12.0,16.0)" Id="Microsoft.VisualStudio.IntegratedShell" />
+	</Installation>
+	<Dependencies>
+		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+		<Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="[11.0]" />
+	</Dependencies>
+	<Assets>
+		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+	</Assets>
+	<Prerequisites>
+		<Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[11.0,16.0)" DisplayName="Visual Studio core editor" />
+	</Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
The project VSToolBox did not compile on my computer since the product name in the manifest was on illegal form:
SQLite SQL Server / Compact Toolbox
I had to change it to:
SQLite SQL Server/Compact Toolbox to be able to compile

What seems to happen with the build is that the product name is used as a part of the deployment path for the VISX export.
Having space surrounding the backslash leads to unwriteable path.
This was observed in VS2017  v. 15.5.1

