### PR TITLE
fix NullReferenceException when calling WriteIntoFile

### DIFF
--- a/src/API/Generator/Helper.cs
+++ b/src/API/Generator/Helper.cs
@@ -28,7 +28,7 @@ namespace ErikEJ.SqlCeScripting
             }
         }
 
-        private static string finalFiles;
+        private static string finalFiles = string.Empty;
 
         public static void WriteIntoFile(string script, string fileLocation, int increment, bool sqlite)
         {


### PR DESCRIPTION
Fix a NullReferenceException when WriteIntoFile is call the first time.

Step to reproduce
Using Generator4 class, call GenerateAllAndSave method against big database to have many files on output...
This exception occurs because finalFiles var is null on WriteIntoFile method