### PR TITLE
Show message with only OK button

### DIFF
--- a/src/GUI/SqlCe35Toolbox/Helpers/EnvDTEHelper.cs
+++ b/src/GUI/SqlCe35Toolbox/Helpers/EnvDTEHelper.cs
@@ -192,9 +192,9 @@ namespace ErikEJ.SqlCeToolbox.Helpers
             VS.MessageBox.ShowError(errorText);
         }
 
-        public static bool ShowMessage(string messageText)
+        public static void ShowMessage(string messageText)
         {
-            return VS.MessageBox.ShowConfirm(messageText);
+            VS.MessageBox.Show(messageText, buttons: OLEMSGBUTTON.OLEMSGBUTTON_OK);
         }
 
         // <summary>


### PR DESCRIPTION
Many actions, e.g. scripting SQLite database showed a message window with `Yes` and `No` buttons:

![Yes No](https://user-images.githubusercontent.com/12699216/210365599-1abe027c-3d58-4a7a-bb4e-f3a905d17557.png)

This confused me, which one to click, especially as it makes no difference. So this will change to display only `OK` button:

![OK](https://user-images.githubusercontent.com/12699216/210366286-34349006-5935-4b68-b9a5-c8d1ae403ba4.png)